### PR TITLE
Add load balancer setting for two ZFP endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 port=8194
-host=cloudpoint1.bloomberg.com
+host1=cloudpoint1.bloomberg.com
+host2=cloudpoint1.bloomberg.com
 health_check_port=80
 
 
@@ -7,7 +8,8 @@ health_check_port=80
 run: build
 	docker run --rm --name bpipe-mock-appliance \
 	-p $(port):$(port) -p $(health_check_port):$(health_check_port) \
-	--env HOST=$(host) \
+	--env HOST1=${host1} \
+    --env HOST2=${host2} \
 	--env PORT=$(port) \
 	--env HEALTH_CHECK_PORT=$(health_check_port) \
 	bpipe-mock-appliance

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 port=8194
 host1=cloudpoint1.bloomberg.com
-host2=cloudpoint1.bloomberg.com
+host2=cloudpoint2.bloomberg.com
 health_check_port=80
 
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ Note that this is a dummy and is used only to prevent the LB target group from s
 * `make run` : This will point you to a ZFP B-PIPE at port 8194, with healthcheck on port 80.
 * `make run host=1223.bbg.com port=8194 health_check_port=8888` : This example sets all the parameters manually.
 
+
+## Build an docker image
+```
+sh buildDocker.sh
+```
+
+## Run as standalone docker service
+```
+sh runDockerInstance.sh
+```
+
+## Reference
+https://docs.nginx.com/nginx/admin-guide/load-balancer/tcp-udp-load-balancer/

--- a/buildDocker.sh
+++ b/buildDocker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker build --tag bpipe-appliance-proxy:v0.alpine .
+

--- a/runDockerInstance.sh
+++ b/runDockerInstance.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+
+if [ -z "$BPIPEHOSTNAME1" ] ; then echo "No env variable BPIPEHOSTNAME1 defined "; exit -1; fi
+if [ -z "$BPIPEHOSTNAME2" ] ; then echo "No env variable BPIPEHOSTNAME2 defined "; exit -1; fi
+if [ -z "$BPIPEPORT" ] ; then echo "No env variable BPIPEPORT defined "; exit -1;fi
+if [ -z "$HEALTH_CHECK_PORT" ]; then echo "No health check port defined"; exit -1; fi
+
+
+docker run -dit  \
+	-p ${BPIPEPORT}:${BPIPEPORT} \
+    -p ${HEALTH_CHECK_PORT}:${HEALTH_CHECK_PORT} \
+	-e HOST1=${BPIPEHOSTNAME1} \
+    -e HOST2=${BPIPEHOSTNAME2} \
+	-e PORT=${BPIPEPORT} \
+	-e HEALTH_CHECK_PORT=${HEALTH_CHECK_PORT} \
+	bpipe-appliance-proxy:v0.alpine

--- a/stream.template.conf
+++ b/stream.template.conf
@@ -3,9 +3,13 @@ events {
 }
 
 stream {
+    upstream stream_backend {
+        server ${HOST1}:${PORT};
+        server ${HOST2}:${PORT};
+    }
     server {
         listen ${PORT};
-        proxy_pass ${HOST}:${PORT};
+        proxy_pass stream_backend;
     }
 
 }


### PR DESCRIPTION
ZFP provides 2 endpoint. We can use the nginx load balancing feature to enhance availability at proxy side.